### PR TITLE
Update documentation with repository name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Repository Name
+# Reusable Workflows
 
 ## Table of Contents
 
-- [Repository Name](#repository-name)
+- [Reusable Workflows](#reusable-workflows)
   - [Table of Contents](#table-of-contents)
   - [Contributing](#contributing)
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -6,7 +6,7 @@ If you discover a security vulnerability within this project, please report it t
 
 To report a vulnerability:
 
-1. Go to the [Security tab](https://github.com/JackPlowman/repository-template/security) of the repository.
+1. Go to the [Security tab](https://github.com/JackPlowman/reusable-workflows/security) of the repository.
 2. Click on "Report a vulnerability".
 3. Follow the instructions to provide details about the vulnerability.
 
@@ -20,6 +20,6 @@ We release patches for security vulnerabilities in the following versions:
 
 ## Security Updates
 
-We will notify users about security updates through the repository's release notes and the [Security Advisories](https://github.com/JackPlowman/repository-template/security/advisories) section.
+We will notify users about security updates through the repository's release notes and the [Security Advisories](https://github.com/JackPlowman/reusable-workflows/security/advisories) section.
 
 Thank you for helping to keep this project secure.


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the repository's documentation to reflect a name change from "repository-template" to "reusable-workflows." The changes primarily focus on updating references in the `README.md` and `SECURITY.md` files.

### Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1-R5): Updated the repository name in the title and table of contents to "Reusable Workflows."
* [`docs/SECURITY.md`](diffhunk://#diff-2605206b7e64be69186fabc8e8fed35676e0015832ff630141aa4aecd73354e0L9-R9): Updated URLs in the "Report a vulnerability" section and the "Security Updates" section to point to the "reusable-workflows" repository instead of "repository-template." [[1]](diffhunk://#diff-2605206b7e64be69186fabc8e8fed35676e0015832ff630141aa4aecd73354e0L9-R9) [[2]](diffhunk://#diff-2605206b7e64be69186fabc8e8fed35676e0015832ff630141aa4aecd73354e0L23-R23)
