### PR TITLE
Add SuperLinter Reusable Workflow

### DIFF
--- a/.github/workflows/run-reusable-worklows.yml
+++ b/.github/workflows/run-reusable-worklows.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches: [main]
 
+permissions: {}
+
 jobs:
   super-linter:
     name: "Run Reusable Workflows"

--- a/.github/workflows/run-reusable-worklows.yml
+++ b/.github/workflows/run-reusable-worklows.yml
@@ -1,0 +1,10 @@
+name: "Run Reusable Workflows"
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  super-linter:
+    name: "Run Reusable Workflows"
+    uses: JackPlowman/reusable-workflows/.github/workflows/super-linter.yml@main

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -1,0 +1,37 @@
+name: "Super Linter"
+
+on:
+  workflow_call:
+    inputs:
+      default_superlinter_configuration:
+        description: "Default superlinter configuration"
+        required: false
+        type: string
+        default: ".github/super-linter-configurations"
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  check-code-quality:
+    name: Check Code Quality
+    runs-on: ubuntu-latest
+    permissions:
+      statuses: write
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      # Lint and Format everything
+      - name: Lint Code Base
+        uses: super-linter/super-linter@v7.3.0
+        env:
+          VALIDATE_ALL_CODEBASE: true
+          DEFAULT_BRANCH: main
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LINTER_RULES_PATH: .github/super-linter-configurations
+          YAML_ERROR_ON_WARNING: true
+          EDITORCONFIG_FILE_NAME: .editorconfig-checker.json

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -9,9 +9,7 @@ on:
         type: string
         default: ".github/super-linter-configurations"
 
-permissions:
-  contents: read
-  packages: read
+permissions: {}
 
 jobs:
   check-code-quality:

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -27,7 +27,7 @@ jobs:
           persist-credentials: false
       # Lint and Format everything
       - name: Lint Code Base
-        uses: super-linter/super-linter@v7.3.0
+        uses: super-linter/super-linter@4e8a7c2bf106c4c766c816b35ec612638dc9b6b2 # v7.3.0
         env:
           VALIDATE_ALL_CODEBASE: true
           DEFAULT_BRANCH: main


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces reusable workflows to streamline code quality checks using GitHub Actions. It includes the addition of a reusable workflow for running Super Linter and a configuration file to define its behavior.

### Addition of reusable workflows:

* [`.github/workflows/run-reusable-worklows.yml`](diffhunk://#diff-250045fa99d200d041d50f003ae73dea85ad0028df828cca968ec02bfd694ad9R1-R10): Added a workflow to trigger the reusable Super Linter workflow on pushes to the `main` branch.
* [`.github/workflows/super-linter.yml`](diffhunk://#diff-3336387af05d3a6efeaa358d145494d23b6036f9034efe8ff6edca2522f06c33R1-R37): Defined a reusable Super Linter workflow with configurable inputs, permissions, and steps to check code quality, including repository checkout and linting with Super Linter.