### PR TITLE
Add SuperLinter Workflow Permissions

### DIFF
--- a/.github/workflows/run-reusable-worklows.yml
+++ b/.github/workflows/run-reusable-worklows.yml
@@ -6,9 +6,10 @@ on:
 
 permissions:
   contents: read
-  statuses: write
 
 jobs:
   super-linter:
     name: "Run Reusable Workflows"
+    permissions:
+      statuses: write
     uses: JackPlowman/reusable-workflows/.github/workflows/super-linter.yml@main

--- a/.github/workflows/run-reusable-worklows.yml
+++ b/.github/workflows/run-reusable-worklows.yml
@@ -4,7 +4,9 @@ on:
   push:
     branches: [main]
 
-permissions: {}
+permissions:
+  contents: read
+  statuses: write
 
 jobs:
   super-linter:


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the permissions configuration in the `.github/workflows/run-reusable-workflows.yml` file to ensure the workflow has the correct access levels.

### Workflow permissions update:
* [`.github/workflows/run-reusable-workflows.yml`](diffhunk://#diff-250045fa99d200d041d50f003ae73dea85ad0028df828cca968ec02bfd694ad9L7-R9): Updated the `permissions` section to grant `contents: read` and `statuses: write` permissions, replacing the previous empty permissions object.