### PR TITLE
Add Common Pull Request Tasks

### DIFF
--- a/.github/workflows/common-pull-request-tasks.yml
+++ b/.github/workflows/common-pull-request-tasks.yml
@@ -1,0 +1,53 @@
+name: "Common Pull Request Tasks"
+on:
+  workflow_call:
+    secrets:
+      workflow_github_token:
+        required: true
+        description: "GitHub token for workflow"
+
+permissions: {}
+
+jobs:
+  labeller:
+    name: Label Pull Request
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Label Pull Request
+        uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
+        with:
+          repo-token: "${{ secrets.workflow_github_token }}"
+          configuration-path: .github/other-configurations/labeller.yml
+          sync-labels: true
+      - name: Add Size Labels
+        uses: pascalgn/size-label-action@f8edde36b3be04b4f65dcfead05dc8691b374348 # v0.5.5
+        env:
+          GITHUB_TOKEN: "${{ secrets.workflow_github_token }}"
+        with:
+          sizes: >
+            {
+              "0": "XS",
+              "40": "S",
+              "100": "M",
+              "200": "L",
+              "800": "XL",
+              "2000": "XXL"
+            }
+
+  dependency-review:
+    name: Dependency Review
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Dependency Review
+        uses: actions/dependency-review-action@38ecb5b593bf0eb19e335c03f97670f792489a8b # v4.7.0
+        with:
+          comment-summary-in-pr: on-failure

--- a/.github/workflows/pull-request-tasks.yml
+++ b/.github/workflows/pull-request-tasks.yml
@@ -8,45 +8,10 @@ permissions:
   pull-requests: read
 
 jobs:
-  labeller:
-    name: Label Pull Request
-    runs-on: ubuntu-latest
+  common-pull-request-tasks:
+    name: Common Pull Request Tasks
     permissions:
       pull-requests: write
-    steps:
-      - name: Label Pull Request
-        uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
-        with:
-          repo-token: "${{ secrets.GITHUB_TOKEN }}"
-          configuration-path: .github/other-configurations/labeller.yml
-          sync-labels: true
-      - name: Add Size Labels
-        uses: pascalgn/size-label-action@f8edde36b3be04b4f65dcfead05dc8691b374348 # v0.5.5
-        env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-        with:
-          sizes: >
-            {
-              "0": "XS",
-              "40": "S",
-              "100": "M",
-              "200": "L",
-              "800": "XL",
-              "2000": "XXL"
-            }
-
-  dependency-review:
-    name: Dependency Review
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - name: Dependency Review
-        uses: actions/dependency-review-action@38ecb5b593bf0eb19e335c03f97670f792489a8b # v4.7.0
-        with:
-          comment-summary-in-pr: on-failure
+    uses: ./.github/workflows/common-pull-request-tasks.yml
+    secrets:
+      workflow_github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Pull Request

## Description

This pull request refactors the pull request workflow by extracting common tasks into a reusable workflow file. The changes aim to improve maintainability and reduce duplication in the GitHub Actions configuration.

### Refactoring of Workflow Configuration:

* Added a new reusable workflow file, `.github/workflows/common-pull-request-tasks.yml`, which consolidates common pull request tasks such as labeling and dependency review. This file defines jobs for labeling pull requests and performing dependency reviews, using the appropriate GitHub Actions and configurations.

* Updated `.github/workflows/pull-request-tasks.yml` to use the new reusable workflow by referencing `common-pull-request-tasks.yml`. This change removes the previously duplicated steps for labeling and dependency review, replacing them with a call to the reusable workflow.
