### PR TITLE
Add Release Workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,23 +1,32 @@
 name: Create Release
 
-on: push
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
-      - name: Checkout branch
+      - name: Checkout Repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
+        with:
+          fetch-depth: 0
+          persist-credentials: false
       - name: Generate release tag
         id: generate_release_tag
         uses: amitsingh-007/next-release-tag@d3025f8b2148fb519af1bcf81b1571d7c6db09df # v6.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          tag_prefix: 'v'
-          tag_template: 'yyyy.mm.dd.i'
-
+          tag_prefix: "v"
+          tag_template: "yyyy.mm.dd.i"
       - name: Create Release
         uses: softprops/action-gh-release@da05d552573ad5aba039eaac05058a918a7bf631 # v2.2.2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,27 @@
+name: Create Release
+
+on: push
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Generate release tag
+        id: generate_release_tag
+        uses: amitsingh-007/next-release-tag@d3025f8b2148fb519af1bcf81b1571d7c6db09df # v6.0.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          tag_prefix: 'v'
+          tag_template: 'yyyy.mm.dd.i'
+
+      - name: Create Release
+        uses: softprops/action-gh-release@da05d552573ad5aba039eaac05058a918a7bf631 # v2.2.2
+        with:
+          name: Release ${{ steps.generate_release_tag.outputs.next_release_tag }}
+          tag_name: ${{ steps.generate_release_tag.outputs.next_release_tag }}
+          token: ${{secrets.GITHUB_TOKEN}}
+          generate_release_notes: true


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces a new GitHub Actions workflow to automate the creation of releases whenever changes are pushed to the `main` branch.

### New GitHub Actions Workflow:
* `.github/workflows/release.yml`: Added a `Create Release` workflow that triggers on pushes to the `main` branch. The workflow:
  - Checks out the repository with the `actions/checkout` action.
  - Generates a release tag using the `amitsingh-007/next-release-tag` action with a customizable tag format (`yyyy.mm.dd.i`).
  - Creates a GitHub release using the `softprops/action-gh-release` action, including automatically generated release notes.