### PR TITLE
Add reusable clean caches workflow

### DIFF
--- a/.github/workflows/clean-caches.yml
+++ b/.github/workflows/clean-caches.yml
@@ -11,14 +11,6 @@ permissions:
 jobs:
   clean-caches:
     name: Clean GitHub Action Caches
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - name: Delete caches
-        run: gh cache delete --all --repo ${{ github.repository }}
-        env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+    uses: ./.github/workflows/common-clean-caches.yml
+    secrets:
+      workflow_github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/common-clean-caches.yml
+++ b/.github/workflows/common-clean-caches.yml
@@ -1,0 +1,26 @@
+name: "Common Clean Caches"
+
+on:
+  workflow_call:
+    secrets:
+      workflow_github_token:
+        required: true
+        description: "GitHub token for workflow"
+
+permissions:
+  contents: read
+
+jobs:
+  clean-caches:
+    name: Clean GitHub Action Caches
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Delete caches
+        run: gh cache delete --all --repo ${{ github.repository }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.workflow_github_token }}


### PR DESCRIPTION
# Pull Request

## Description

This pull request refactors the GitHub Actions workflow for cleaning caches by introducing a reusable workflow file. The changes aim to improve maintainability and reduce duplication.

### Refactoring GitHub Actions workflows:

* [`.github/workflows/clean-caches.yml`](diffhunk://#diff-d0394e4336a74cdfc1d4cff05d056b893ac7ff922eacf4448e104a754f386b8dL14-R16): Replaced the inline job definition with a call to a reusable workflow, `common-clean-caches.yml`, passing the required `GITHUB_TOKEN` secret.
* [`.github/workflows/common-clean-caches.yml`](diffhunk://#diff-13fad14fa3972181d9dae18fc35384d3396e52fd6e985447df6b9257982ce9cbR1-R26): Added a new reusable workflow named "Common Clean Caches" that defines the cache-cleaning job, including permissions, secrets, and steps for checking out the repository and deleting caches.