### PR TITLE
Fix Clean Caches Permissions

### DIFF
--- a/.github/workflows/clean-caches.yml
+++ b/.github/workflows/clean-caches.yml
@@ -7,7 +7,6 @@ on:
 
 permissions: {}
 
-
 jobs:
   clean-caches:
     name: Clean GitHub Action Caches

--- a/.github/workflows/clean-caches.yml
+++ b/.github/workflows/clean-caches.yml
@@ -13,4 +13,4 @@ jobs:
     name: Clean GitHub Action Caches
     uses: ./.github/workflows/common-clean-caches.yml
     secrets:
-      workflow_github_token: ${{ secrets.GITHUB_TOKEN }}
+      workflow_github_token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/clean-caches.yml
+++ b/.github/workflows/clean-caches.yml
@@ -5,12 +5,14 @@ on:
     - cron: "0 0 1 * *"
   workflow_dispatch:
 
-permissions:
-  contents: read
+permissions: {}
+
 
 jobs:
   clean-caches:
     name: Clean GitHub Action Caches
     uses: ./.github/workflows/common-clean-caches.yml
+    permissions:
+      contents: read
     secrets:
       workflow_github_token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/common-clean-caches.yml
+++ b/.github/workflows/common-clean-caches.yml
@@ -14,7 +14,7 @@ jobs:
     name: Clean GitHub Action Caches
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
     steps:
       - name: Checkout Repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/common-clean-caches.yml
+++ b/.github/workflows/common-clean-caches.yml
@@ -7,13 +7,14 @@ on:
         required: true
         description: "GitHub token for workflow"
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   clean-caches:
     name: Clean GitHub Action Caches
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout Repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
# Pull Request

## Description


This pull request updates the permissions configuration in two GitHub Actions workflows to improve clarity and security. The changes include switching to an empty permissions object at the workflow level and explicitly defining permissions at the job level. Additionally, the token used for secrets has been updated.

### Permissions configuration updates:

* [`.github/workflows/clean-caches.yml`](diffhunk://#diff-d0394e4336a74cdfc1d4cff05d056b893ac7ff922eacf4448e104a754f386b8dL8-R18): Replaced the workflow-level `permissions` configuration with an empty object (`{}`) and moved the `contents: read` permission to the job level.
* [`.github/workflows/common-clean-caches.yml`](diffhunk://#diff-13fad14fa3972181d9dae18fc35384d3396e52fd6e985447df6b9257982ce9cbL10-R17): Aligned with the same approach by replacing the workflow-level `permissions` configuration with an empty object (`{}`) and explicitly adding `contents: read` at the job level.

### Token update:

* [`.github/workflows/clean-caches.yml`](diffhunk://#diff-d0394e4336a74cdfc1d4cff05d056b893ac7ff922eacf4448e104a754f386b8dL8-R18): Updated the `workflow_github_token` secret to use `GH_TOKEN` instead of `GITHUB_TOKEN` for consistency or improved functionality.