### PR TITLE
Add Common Sync Labels Reusable Workflow

### DIFF
--- a/.github/workflows/common-sync-labels.yml
+++ b/.github/workflows/common-sync-labels.yml
@@ -1,0 +1,29 @@
+name: "Sync labels"
+
+on:
+  workflow_call:
+    secrets:
+      workflow_github_token:
+        required: true
+        description: "GitHub token for workflow"
+
+permissions: {}
+
+jobs:
+  configure-labels:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Sync labels
+        uses: micnncim/action-label-syncer@3abd5ab72fda571e69fffd97bd4e0033dd5f495c # v1.3.0
+        with:
+          token: ${{ secrets.workflow_github_token }}
+          repository: ${{ github.repository }}
+          manifest: .github/other-configurations/labels.yml

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -6,25 +6,15 @@ on:
       - main
     paths:
       - .github/other-configurations/labels.yml
+  workflow_dispatch:
 
-permissions:
-  contents: read
-  pull-requests: read
+permissions: {}
 
 jobs:
   configure-labels:
-    runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: write
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - name: Sync labels
-        uses: micnncim/action-label-syncer@3abd5ab72fda571e69fffd97bd4e0033dd5f495c # v1.3.0
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          repository: ${{ github.repository }}
-          manifest: .github/other-configurations/labels.yml
+    uses: ./.github/workflows/common-sync-labels.yml
+    secrets:
+      workflow_github_token: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
# Pull Request

## Description

This pull request refactors the GitHub Actions workflow for syncing labels by introducing a reusable workflow and updating the existing workflow to use it. The changes aim to improve maintainability and reduce duplication.

### Refactoring workflows:

* Added a new reusable workflow `.github/workflows/common-sync-labels.yml` to handle label synchronization. This workflow includes steps for checking out the repository and syncing labels using the `micnncim/action-label-syncer` action.

* Updated the existing workflow `.github/workflows/sync-labels.yml` to use the new reusable workflow. The `permissions` block and `workflow_dispatch` trigger were also adjusted for compatibility.