### PR TITLE
Fix Reusable Workflows Permissions

### DIFF
--- a/.github/workflows/run-reusable-worklows.yml
+++ b/.github/workflows/run-reusable-worklows.yml
@@ -24,7 +24,7 @@ jobs:
       contents: read
     uses: JackPlowman/reusable-workflows/.github/workflows/common-clean-caches.yml@main
     secrets:
-      workflow_github_token: ${{ secrets.GITHUB_TOKEN }}
+      workflow_github_token: ${{ secrets.GH_TOKEN }}
 
   common-sync-labels:
     name: Common Sync Labels


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the `.github/workflows/run-reusable-workflows.yml` file to use a different secret for authentication in the `common-clean-caches` reusable workflow.

* Updated the `workflow_github_token` secret to use `${{ secrets.GH_TOKEN }}` instead of `${{ secrets.GITHUB_TOKEN }}` in the `common-clean-caches` job.