### PR TITLE
Force Common Code Checks use colour ouput

### DIFF
--- a/.github/workflows/common-code-checks.yml
+++ b/.github/workflows/common-code-checks.yml
@@ -10,6 +10,10 @@ on:
 permissions:
   contents: read
 
+
+env:
+  FORCE_COLOR: 1
+
 jobs:
   check-markdown-links:
     name: Check Markdown links

--- a/.github/workflows/common-code-checks.yml
+++ b/.github/workflows/common-code-checks.yml
@@ -10,7 +10,6 @@ on:
 permissions:
   contents: read
 
-
 env:
   FORCE_COLOR: 1
 


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces an environment variable to the GitHub Actions workflow to ensure colored output during execution.

* [`.github/workflows/common-code-checks.yml`](diffhunk://#diff-d4fd1616efd0d349042c6f234e04f6a67b1cf5c85a83ef463226a145f0c1cec6R13-R16): Added the `FORCE_COLOR` environment variable with a value of `1` to enforce colored output in the workflow.