### PR TITLE
Update Lefthook to remove Pinact Verify

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -18,5 +18,3 @@ pre-commit:
       run: just lefthook-validate
     Zizmor Checks:
       run: just zizmor-check
-    Pinact Verify:
-      run: just pinact-check


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the `lefthook.yml` configuration file by removing an outdated pre-commit hook.

Configuration changes:

* [`lefthook.yml`](diffhunk://#diff-ad6a01e589b8b1b214ca310dbb8d2e4314f6c612b921050c73c97455de43884dL21-L22): Removed the `Pinact Verify` pre-commit hook, which previously ran the `just pinact-check` command.