### PR TITLE
Ignore Pinact Warnings

### DIFF
--- a/.github/other-configurations/pinact.yml
+++ b/.github/other-configurations/pinact.yml
@@ -1,0 +1,10 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/suzuki-shunsuke/pinact/main/json-schema/pinact.json
+version: 3
+
+ignore_actions:
+  - name: "JackPlowman/reusable-workflows/.github/workflows/common-code-checks.yml"
+    ref: "main"
+  - name: "JackPlowman/reusable-workflows/.github/workflows/common-clean-caches.yml"
+    ref: "main"
+  - name: "JackPlowman/reusable-workflows/.github/workflows/common-sync-labels.yml"
+    ref: "main"

--- a/Justfile
+++ b/Justfile
@@ -54,17 +54,19 @@ zizmor-check-sarif:
 # Pinact
 # ------------------------------------------------------------------------------
 
+export pinact_config := "-c .github/other-configurations/pinact.yml"
+
 # Run pinact
 pinact-run:
-    pinact run
+    pinact run ${pinact_config}
 
 # Run pinact checking
 pinact-check:
-    pinact run --verify --check
+    pinact run ${pinact_config} --verify --check
 
 # Run pinact update
 pinact-update:
-    pinact run --update
+    pinact run ${pinact_config} --update
 
 # ------------------------------------------------------------------------------
 # Git Hooks


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces configuration and integration for Pinact, a tool for managing reusable workflows. The changes include adding a new configuration file and updating commands in the `Justfile` to reference the configuration.

### Pinact Configuration:

* Added a new Pinact configuration file `.github/other-configurations/pinact.yml` with schema validation, versioning, and a list of reusable workflows to ignore.

### Pinact Integration:

* Updated the `Justfile` to include a `pinact_config` variable pointing to the new configuration file and modified all Pinact-related commands (`pinact-run`, `pinact-check`, `pinact-update`) to use this configuration.