### PR TITLE
Update Sync Labels Workflow

### DIFF
--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -17,4 +17,4 @@ jobs:
       pull-requests: write
     uses: ./.github/workflows/common-sync-labels.yml
     secrets:
-      workflow_github_token: ${{ secrets.GH_TOKEN }}
+      workflow_github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a small update to the `.github/workflows/sync-labels.yml` file. The change updates the secret used for the `workflow_github_token` from `GH_TOKEN` to `GITHUB_TOKEN`.