### PR TITLE
Update `Check Markdown links` Job Permissions

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -36,7 +36,7 @@ jobs:
     name: Common Code Checks
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       security-events: write
     uses: ./.github/workflows/common-code-checks.yml
     secrets:

--- a/.github/workflows/common-code-checks.yml
+++ b/.github/workflows/common-code-checks.yml
@@ -18,7 +18,7 @@ jobs:
     name: Check Markdown links
     runs-on: ubuntu-latest
     permissions:
-      pull-requests: read
+      pull-requests: write
     steps:
       - name: Checkout Repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/run-reusable-worklows.yml
+++ b/.github/workflows/run-reusable-worklows.yml
@@ -12,7 +12,7 @@ jobs:
     name: Common Code Checks
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       security-events: write
     uses: JackPlowman/reusable-workflows/.github/workflows/common-code-checks.yml@main
     secrets:


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the permissions for GitHub Actions workflows to allow write access to pull requests. These changes ensure that the workflows have the necessary permissions to perform actions like commenting or updating pull requests.

### Permissions updates for workflows:

* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L39-R39): Updated `pull-requests` permission from `read` to `write` in the `Common Code Checks` job.
* [`.github/workflows/common-code-checks.yml`](diffhunk://#diff-d4fd1616efd0d349042c6f234e04f6a67b1cf5c85a83ef463226a145f0c1cec6L21-R21): Updated `pull-requests` permission from `read` to `write` in the `Check Markdown links` job.
* [`.github/workflows/run-reusable-worklows.yml`](diffhunk://#diff-250045fa99d200d041d50f003ae73dea85ad0028df828cca968ec02bfd694ad9L15-R15): Updated `pull-requests` permission from `read` to `write` in the `Common Code Checks` job for the reusable workflow.