### PR TITLE
Remove Unnecessary Secrets

### DIFF
--- a/.github/workflows/run-reusable-worklows.yml
+++ b/.github/workflows/run-reusable-worklows.yml
@@ -43,5 +43,3 @@ jobs:
     uses: JackPlowman/reusable-workflows/.github/workflows/codeql-analysis.yml@main
     with:
       language: actions
-    secrets:
-      workflow_github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Pull Request

## Description

This pull request removes unused secrets from the `jobs` section of the `.github/workflows/run-reusable-workflows.yml` file to streamline the workflow configuration.

* Workflow configuration cleanup:
  * [`.github/workflows/run-reusable-workflows.yml`](diffhunk://#diff-250045fa99d200d041d50f003ae73dea85ad0028df828cca968ec02bfd694ad9L46-L47): Removed the `secrets` block, including `workflow_github_token`, as it is no longer required.
