### PR TITLE
Bump GitHub Actions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -24,10 +24,10 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@60168efe1c415ce0f5521ea06d5c2062adbeed1b # v3.28.17
+        uses: github/codeql-action/init@ff0a06e83cb2de871e5a09832bc6a81e7276941f # v3.28.18
         with:
           languages: ${{ inputs.language }}
           queries: security-and-quality
           config-file: GitHubSecurityLab/CodeQL-Community-Packs/configs/default.yml@v0.2.1
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@60168efe1c415ce0f5521ea06d5c2062adbeed1b # v3.28.17
+        uses: github/codeql-action/analyze@ff0a06e83cb2de871e5a09832bc6a81e7276941f # v3.28.18

--- a/.github/workflows/common-code-checks.yml
+++ b/.github/workflows/common-code-checks.yml
@@ -61,7 +61,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca # v6.0.1
+        uses: astral-sh/setup-uv@f0ec1fc3b38f5e7cd731bb6ce540c5af426746bb # v6.1.0
       - name: Set up Just
         uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3.0.0
       - name: Run zizmor 🌈
@@ -84,6 +84,6 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca # v6.0.1
+        uses: astral-sh/setup-uv@f0ec1fc3b38f5e7cd731bb6ce540c5af426746bb # v6.1.0
       - name: Run Lefthook Validate
         run: uvx lefthook validate


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates dependencies in GitHub Actions workflows to ensure compatibility and access to the latest features and fixes. The changes involve bumping versions for the CodeQL and `setup-uv` actions.

### Dependency Updates:

* [`.github/workflows/codeql-analysis.yml`](diffhunk://#diff-63bd641104d10e25f141d518a16b22a151d125e12701df2f9e79734b23b90188L27-R33): Updated the `github/codeql-action/init` and `github/codeql-action/analyze` actions from version `v3.28.17` to `v3.28.18` to include the latest improvements and fixes.

* [`.github/workflows/common-code-checks.yml`](diffhunk://#diff-d4fd1616efd0d349042c6f234e04f6a67b1cf5c85a83ef463226a145f0c1cec6L64-R64): Updated the `astral-sh/setup-uv` action from version `v6.0.1` to `v6.1.0` to ensure the latest version of `uv` is installed. [[1]](diffhunk://#diff-d4fd1616efd0d349042c6f234e04f6a67b1cf5c85a83ef463226a145f0c1cec6L64-R64) [[2]](diffhunk://#diff-d4fd1616efd0d349042c6f234e04f6a67b1cf5c85a83ef463226a145f0c1cec6L87-R87)