### PR TITLE
Update CodeQL Actions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -24,10 +24,10 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@ff0a06e83cb2de871e5a09832bc6a81e7276941f # v3.28.18
+        uses: github/codeql-action/init@fca7ace96b7d713c7035871441bd52efbe39e27e # v3.28.19
         with:
           languages: ${{ inputs.language }}
           queries: security-and-quality
           config-file: GitHubSecurityLab/CodeQL-Community-Packs/configs/default.yml@v0.2.1
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@ff0a06e83cb2de871e5a09832bc6a81e7276941f # v3.28.18
+        uses: github/codeql-action/analyze@fca7ace96b7d713c7035871441bd52efbe39e27e # v3.28.19

--- a/.github/workflows/common-code-checks.yml
+++ b/.github/workflows/common-code-checks.yml
@@ -69,7 +69,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.workflow_github_token }}
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@ff0a06e83cb2de871e5a09832bc6a81e7276941f # v3.28.18
+        uses: github/codeql-action/upload-sarif@fca7ace96b7d713c7035871441bd52efbe39e27e # v3.28.19
         with:
           sarif_file: results.sarif
           category: zizmor


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the CodeQL actions in GitHub workflow files to use the latest version (`v3.28.19`) for improved security and functionality.

Updates to CodeQL actions in workflows:

* [`.github/workflows/codeql-analysis.yml`](diffhunk://#diff-63bd641104d10e25f141d518a16b22a151d125e12701df2f9e79734b23b90188L27-R33): Updated `github/codeql-action/init` and `github/codeql-action/analyze` actions to use version `v3.28.19` instead of `v3.28.18`.
* [`.github/workflows/common-code-checks.yml`](diffhunk://#diff-d4fd1616efd0d349042c6f234e04f6a67b1cf5c85a83ef463226a145f0c1cec6L72-R72): Updated `github/codeql-action/upload-sarif` action to use version `v3.28.19` instead of `v3.28.18`.
