### PR TITLE
Migrate Zizmor Checks to Zizmor Action

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -36,6 +36,7 @@ jobs:
     name: Common Code Checks
     permissions:
       contents: read
+      actions: read
       pull-requests: write
       security-events: write
     uses: ./.github/workflows/common-code-checks.yml

--- a/.github/workflows/common-code-checks.yml
+++ b/.github/workflows/common-code-checks.yml
@@ -66,7 +66,7 @@ jobs:
         uses: zizmorcore/zizmor-action@f52a838cfabf134edcbaa7c8b3677dde20045018 # v0.1.1
         with:
           persona: pedantic
-          version: v1.9.0
+          version: 1.9.0
 
   lefthook-validate:
     name: Lefthook Validate

--- a/.github/workflows/common-code-checks.yml
+++ b/.github/workflows/common-code-checks.yml
@@ -53,6 +53,8 @@ jobs:
     name: Check GitHub Actions with zizmor
     runs-on: ubuntu-latest
     permissions:
+      contents: read
+      actions: read
       security-events: write
     steps:
       - name: Checkout Repository
@@ -60,19 +62,11 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@f0ec1fc3b38f5e7cd731bb6ce540c5af426746bb # v6.1.0
-      - name: Set up Just
-        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3.0.0
       - name: Run zizmor 🌈
-        run: just zizmor-check-sarif
-        env:
-          GH_TOKEN: ${{ secrets.workflow_github_token }}
-      - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@fca7ace96b7d713c7035871441bd52efbe39e27e # v3.28.19
+        uses: zizmorcore/zizmor-action@f52a838cfabf134edcbaa7c8b3677dde20045018 # v0.1.1
         with:
-          sarif_file: results.sarif
-          category: zizmor
+          persona: pedantic
+          version: v1.9.0
 
   lefthook-validate:
     name: Lefthook Validate

--- a/Justfile
+++ b/Justfile
@@ -46,10 +46,6 @@ lefthook-validate:
 zizmor-check:
     uvx zizmor . --persona=pedantic
 
-# Run zizmor checking with sarif output
-zizmor-check-sarif:
-    uvx zizmor . --persona=pedantic --format sarif > results.sarif
-
 # ------------------------------------------------------------------------------
 # Pinact
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates workflows and configurations to streamline code checks and simplify the execution of the `zizmor` tool. The most significant changes include modifying permissions in workflow files, replacing manual steps with a dedicated `zizmor` action, and removing unused commands from the `Justfile`.

### Workflow updates:

* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4R39): Added `actions: read` permission to improve compatibility with GitHub Actions.
* [`.github/workflows/common-code-checks.yml`](diffhunk://#diff-d4fd1616efd0d349042c6f234e04f6a67b1cf5c85a83ef463226a145f0c1cec6R56-R69): Updated permissions to include `actions: read`, removed steps for installing `uv` and setting up `Just`, and replaced manual `zizmor` execution with the `zizmor-action` GitHub Action for streamlined checks.

### Configuration simplification:

* [`Justfile`](diffhunk://#diff-2f90408c2b0302b1cdb7f5d634114750837f940fa82d13057d9c18d0170a7e5cL49-L52): Removed the `zizmor-check-sarif` command, simplifying the configuration by eliminating unused SARIF output generation.