### PR TITLE
Bump softprops/action-gh-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
           tag_prefix: "v"
           tag_template: "yyyy.mm.dd.i"
       - name: Create Release
-        uses: softprops/action-gh-release@d5382d3e6f2fa7bd53cb749d33091853d4985daf # v2.3.0
+        uses: softprops/action-gh-release@72f2c25fcb47643c292f7107632f7a47c1df5cd8 # v2.3.2
         with:
           name: Release ${{ steps.generate_release_tag.outputs.next_release_tag }}
           tag_name: ${{ steps.generate_release_tag.outputs.next_release_tag }}


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the GitHub Actions workflow for releases by upgrading the `softprops/action-gh-release` action to a newer version.

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L34-R34): Updated the `softprops/action-gh-release` action from version `v2.3.0` to `v2.3.2` to ensure compatibility and access to the latest improvements.