### PR TITLE
Add Pinact Check Job

### DIFF
--- a/.github/workflows/common-code-checks.yml
+++ b/.github/workflows/common-code-checks.yml
@@ -92,7 +92,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Pin actions
-        uses: suzuki-shunsuke/pinact-action@v1.0.0
+        uses: suzuki-shunsuke/pinact-action@49cbd6acd0dbab6a6be2585d1dbdaa43b4410133 # v1.0.0
         with:
           skip_push: "true"
         env:


### PR DESCRIPTION
# Pull Request

## Description

This pull request adds a new job to `.github/workflows/common-code-checks.yml` for performing a Pinact check. The job ensures that GitHub Actions used in the repository are pinned to specific versions for security and reliability.

Workflow updates:

* [`.github/workflows/common-code-checks.yml`](diffhunk://#diff-d4fd1616efd0d349042c6f234e04f6a67b1cf5c85a83ef463226a145f0c1cec6R84-R99): Added a new job named `pinact-check` to validate that GitHub Actions are pinned to specific versions using the `pinact-action`. This job includes steps to checkout the repository and run the Pinact validation based on the configuration in `.github/other-configurations/pinact.yml`.