### PR TITLE
Add Actionlint Job

### DIFF
--- a/.github/workflows/common-code-checks.yml
+++ b/.github/workflows/common-code-checks.yml
@@ -109,3 +109,5 @@ jobs:
           persist-credentials: false
       - name: Run Actionlint
         uses: docker://rhysd/actionlint:1.7.7 # zizmor: ignore[unpinned-uses]
+        with:
+          args: -color

--- a/.github/workflows/common-code-checks.yml
+++ b/.github/workflows/common-code-checks.yml
@@ -108,4 +108,4 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Run Actionlint
-        uses: docker://rhysd/actionlint:sha256:887a259a5a534f3c4f36cb02dca341673c6089431057242cdc931e9f133147 # v1.7.7
+        uses: docker://rhysd/actionlint:887a259a5a534f3c4f36cb02dca341673c6089431057242cdc931e9f133147 # v1.7.7

--- a/.github/workflows/common-code-checks.yml
+++ b/.github/workflows/common-code-checks.yml
@@ -97,3 +97,15 @@ jobs:
           skip_push: "true"
         env:
           PINACT_CONFIG: .github/other-configurations/pinact.yml
+
+  run-actionlint:
+    name: Run Actionlint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Run Actionlint
+        uses: docker://rhysd/actionlint:887a259a5a534f3c4f36cb02dca341673c6089431057242cdc931e9f133147e9 # v1.7.7

--- a/.github/workflows/common-code-checks.yml
+++ b/.github/workflows/common-code-checks.yml
@@ -108,4 +108,4 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Run Actionlint
-        uses: docker://rhysd/actionlint:887a259a5a534f3c4f36cb02dca341673c6089431057242cdc931e9f133147 # v1.7.7
+        uses: docker://rhysd/actionlint:1.7.7

--- a/.github/workflows/common-code-checks.yml
+++ b/.github/workflows/common-code-checks.yml
@@ -108,4 +108,4 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Run Actionlint
-        uses: docker://rhysd/actionlint:887a259a5a534f3c4f36cb02dca341673c6089431057242cdc931e9f133147e9 # v1.7.7
+        uses: docker://rhysd/actionlint:sha256:887a259a5a534f3c4f36cb02dca341673c6089431057242cdc931e9f133147 # v1.7.7

--- a/.github/workflows/common-code-checks.yml
+++ b/.github/workflows/common-code-checks.yml
@@ -99,7 +99,7 @@ jobs:
           PINACT_CONFIG: .github/other-configurations/pinact.yml
 
   run-actionlint:
-    name: Run Actionlint
+    name: Check GitHub Actions with Actionlint
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
@@ -108,4 +108,4 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Run Actionlint
-        uses: docker://rhysd/actionlint:1.7.7
+        uses: docker://rhysd/actionlint:1.7.7 # zizmor: ignore[unpinned-uses]


### PR DESCRIPTION
# Pull Request

## Description


This pull request introduces a new job to the `.github/workflows/common-code-checks.yml` file for validating GitHub Actions using Actionlint. The change improves the CI pipeline by adding static analysis for workflow files.

Enhancements to CI pipeline:

* [`.github/workflows/common-code-checks.yml`](diffhunk://#diff-d4fd1616efd0d349042c6f234e04f6a67b1cf5c85a83ef463226a145f0c1cec6R100-R111): Added a new `run-actionlint` job to check GitHub Actions workflows using Actionlint, including steps for repository checkout and running Actionlint via Docker.