### PR TITLE
Set Zizmor persona to auditor

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -44,7 +44,7 @@ lefthook-validate:
 
 # Run zizmor checking
 zizmor-check:
-    uvx zizmor . --persona=pedantic
+    uvx zizmor . --persona=auditor
 
 # ------------------------------------------------------------------------------
 # Pinact


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a minor update to the `Justfile`. The change modifies the `lefthook-validate:` configuration to use a different persona for the `zizmor-check` command.

* [`Justfile`](diffhunk://#diff-2f90408c2b0302b1cdb7f5d634114750837f940fa82d13057d9c18d0170a7e5cL47-R47): Updated the `zizmor-check` command to use the `auditor` persona instead of `pedantic`.