### PR TITLE
Handle Pinact Config if exists 

### DIFF
--- a/.github/workflows/common-code-checks.yml
+++ b/.github/workflows/common-code-checks.yml
@@ -97,7 +97,7 @@ jobs:
         with:
           skip_push: "true"
         env:
-            PINACT_CONFIG: .github/other-configurations/pinact.yml
+          PINACT_CONFIG: .github/other-configurations/pinact.yml
       - name: Check actions are pinned (without config)
         if: ${{ hashFiles('.github/other-configurations/pinact.yml') == '' }}
         uses: suzuki-shunsuke/pinact-action@49cbd6acd0dbab6a6be2585d1dbdaa43b4410133 # v1.0.0

--- a/.github/workflows/common-code-checks.yml
+++ b/.github/workflows/common-code-checks.yml
@@ -91,12 +91,18 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - name: Pin actions
+      - name: Check actions are pinned (with config)
+        if: ${{ hashFiles('.github/other-configurations/pinact.yml') != '' }}
         uses: suzuki-shunsuke/pinact-action@49cbd6acd0dbab6a6be2585d1dbdaa43b4410133 # v1.0.0
         with:
           skip_push: "true"
         env:
-          PINACT_CONFIG: .github/other-configurations/pinact.yml
+            PINACT_CONFIG: .github/other-configurations/pinact.yml
+      - name: Check actions are pinned (without config)
+        if: ${{ hashFiles('.github/other-configurations/pinact.yml') == '' }}
+        uses: suzuki-shunsuke/pinact-action@49cbd6acd0dbab6a6be2585d1dbdaa43b4410133 # v1.0.0
+        with:
+          skip_push: "true"
 
   run-actionlint:
     name: Check GitHub Actions with Actionlint


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the `.github/workflows/common-code-checks.yml` file to enhance the validation of pinned GitHub Actions. The changes introduce conditional checks to ensure actions are pinned, both when a configuration file is present and when it is absent.

Enhancements to GitHub Actions validation:

* [`.github/workflows/common-code-checks.yml`](diffhunk://#diff-d4fd1616efd0d349042c6f234e04f6a67b1cf5c85a83ef463226a145f0c1cec6L94-R105): Added two separate steps to check if actions are pinned. One step runs when the configuration file `.github/other-configurations/pinact.yml` is present, and another runs when the file is absent. This ensures comprehensive validation regardless of configuration availability.