### PR TITLE
Bump Zizmor version to v1.11.0

### DIFF
--- a/.github/workflows/common-code-checks.yml
+++ b/.github/workflows/common-code-checks.yml
@@ -66,7 +66,7 @@ jobs:
         uses: zizmorcore/zizmor-action@f52a838cfabf134edcbaa7c8b3677dde20045018 # v0.1.1
         with:
           persona: auditor
-          version: 1.10.0
+          version: 1.11.0
 
   lefthook-validate:
     name: Lefthook Validate


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the version of the `zizmor-action` tool used in the `.github/workflows/common-code-checks.yml` file to ensure compatibility with the latest features and fixes.

* [`.github/workflows/common-code-checks.yml`](diffhunk://#diff-d4fd1616efd0d349042c6f234e04f6a67b1cf5c85a83ef463226a145f0c1cec6L69-R69): Updated the `version` parameter for `zizmor-action` from `1.10.0` to `1.11.0` under the `jobs:` section.