### PR TITLE
Bump Linkspector

### DIFF
--- a/.github/workflows/common-code-checks.yml
+++ b/.github/workflows/common-code-checks.yml
@@ -26,7 +26,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Check Markdown links
-        uses: UmbrellaDocs/action-linkspector@e2ccef58c4b9eb89cd71ee23a8629744bba75aa6 # v1.3.5
+        uses: UmbrellaDocs/action-linkspector@3a951c1f0dca72300c2320d0eb39c2bafe429ab1 # v1.3.6
         with:
           github_token: ${{ secrets.workflow_github_token }}
           config_file: .github/other-configurations/.linkspector.yml


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the version of the `action-linkspector` GitHub Action used in the `.github/workflows/common-code-checks.yml` file to ensure the workflow is using the latest version of the tool.

* [`.github/workflows/common-code-checks.yml`](diffhunk://#diff-d4fd1616efd0d349042c6f234e04f6a67b1cf5c85a83ef463226a145f0c1cec6L29-R29): Updated `action-linkspector` from version `v1.3.5` (`e2ccef58c4b9eb89cd71ee23a8629744bba75aa6`) to version `v1.3.6` (`3a951c1f0dca72300c2320d0eb39c2bafe429ab1`).