### PR TITLE
Add Grype Scanning Job

### DIFF
--- a/.github/workflows/common-code-checks.yml
+++ b/.github/workflows/common-code-checks.yml
@@ -117,3 +117,20 @@ jobs:
         uses: docker://rhysd/actionlint:1.7.7 # zizmor: ignore[unpinned-uses]
         with:
           args: -color
+
+  run-grype:
+    name: Check for Vulnerabilities with Grype
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Scan current project
+        uses: anchore/scan-action@v6
+        with:
+          path: "."

--- a/.github/workflows/common-code-checks.yml
+++ b/.github/workflows/common-code-checks.yml
@@ -131,6 +131,6 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Scan current project
-        uses: anchore/scan-action@v6
+        uses: anchore/scan-action@16910ac423301c6d30554b83a7f71ac6ff4a51f3 # v6.4.0
         with:
           path: "."


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces a new workflow step to `.github/workflows/common-code-checks.yml` for scanning the repository for vulnerabilities using Grype. 

Workflow addition:

* Added a new job, `run-grype`, to check for vulnerabilities using the Anchore Grype scanning action. This includes setting up permissions, checking out the repository, and scanning the project directory.