### PR TITLE
Add trufflehog job

### DIFF
--- a/.github/workflows/common-code-checks.yml
+++ b/.github/workflows/common-code-checks.yml
@@ -152,3 +152,21 @@ jobs:
         uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2.3.9
         env:
           GITHUB_TOKEN: ${{ github.token}}
+
+  run-trufflehog:
+    name: Check for Secrets with Trufflehog
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Secret Scanning
+        uses: trufflesecurity/trufflehog@6641d4ba5b684fffe195b9820345de1bf19f3181 # v3.89.2
+        with:
+          extra_args: --github-actions --results=verified,unknown


### PR DESCRIPTION
# Pull Request

## Description

This pull request adds a new job to the `.github/workflows/common-code-checks.yml` file for secret scanning using Trufflehog. The addition enhances the repository's security checks by introducing a complementary tool to detect secrets.

Security enhancements:

* [`.github/workflows/common-code-checks.yml`](diffhunk://#diff-d4fd1616efd0d349042c6f234e04f6a67b1cf5c85a83ef463226a145f0c1cec6R155-R172): Added a `run-trufflehog` job to perform secret scanning with Trufflehog. This job checks for secrets in the codebase using GitHub Actions, ensuring comprehensive security coverage alongside existing tools like Gitleaks.