### PR TITLE
Update TruffleHog to v3.90.0

### DIFF
--- a/.github/workflows/common-code-checks.yml
+++ b/.github/workflows/common-code-checks.yml
@@ -167,6 +167,6 @@ jobs:
           persist-credentials: false
 
       - name: Secret Scanning
-        uses: trufflesecurity/trufflehog@6641d4ba5b684fffe195b9820345de1bf19f3181 # v3.89.2
+        uses: trufflesecurity/trufflehog@eafb8c5f6a06175141c27f17bcc17941853d0047 # v3.90.0
         with:
           extra_args: --results=verified,unknown


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the version of the TruffleHog secret scanning tool used in the GitHub Actions workflow.

* [`.github/workflows/common-code-checks.yml`](diffhunk://#diff-d4fd1616efd0d349042c6f234e04f6a67b1cf5c85a83ef463226a145f0c1cec6L170-R170): Updated the TruffleHog action from version `v3.89.2` to `v3.90.0` to ensure the workflow uses the latest features and fixes.