### PR TITLE
Remove Dependabot Groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,14 +8,3 @@ updates:
       cronjob: "30 7 * * *"
       timezone: "Europe/London"
     target-branch: "main"
-    groups:
-      github-actions:
-        applies-to: "version-updates"
-        patterns:
-          - "*"
-        exclude-patterns:
-          - "super-linter/super-linter"
-          - "JackPlowman/reusable-workflows"
-        update-types:
-          - "patch"
-          - "minor"


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a change to the `.github/dependabot.yml` file, specifically removing the `groups` configuration under `updates`. This simplifies the Dependabot configuration by eliminating the grouping of dependencies based on patterns and update types.

Key change:

* Removed the `groups` section, which previously grouped dependencies (e.g., `github-actions`) based on patterns, excluded certain patterns, and specified update types (`patch` and `minor`). This change reduces complexity in the Dependabot configuration. (`[.github/dependabot.ymlL11-L21](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L11-L21)`)