### PR TITLE
Update Linkspector to 1.3.7

### DIFF
--- a/.github/workflows/common-code-checks.yml
+++ b/.github/workflows/common-code-checks.yml
@@ -26,7 +26,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Check Markdown links
-        uses: UmbrellaDocs/action-linkspector@3a951c1f0dca72300c2320d0eb39c2bafe429ab1 # v1.3.6
+        uses: UmbrellaDocs/action-linkspector@874d01cae9fd488e3077b08952093235bd626977 # v1.3.7
         with:
           github_token: ${{ secrets.workflow_github_token }}
           config_file: .github/other-configurations/.linkspector.yml


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the version of the `UmbrellaDocs/action-linkspector` GitHub Action in the `.github/workflows/common-code-checks.yml` file.

* Updated the `UmbrellaDocs/action-linkspector` action from version `3a951c1f0dca72300c2320d0eb39c2bafe429ab1` (v1.3.6) to `874d01cae9fd488e3077b08952093235bd626977` (v1.3.7). This ensures the workflow uses the latest version of the action. (`[.github/workflows/common-code-checks.ymlL29-R29](diffhunk://#diff-d4fd1616efd0d349042c6f234e04f6a67b1cf5c85a83ef463226a145f0c1cec6L29-R29)`)