### PR TITLE
Update Trufflehog

### DIFF
--- a/.github/workflows/common-code-checks.yml
+++ b/.github/workflows/common-code-checks.yml
@@ -178,6 +178,6 @@ jobs:
           persist-credentials: false
 
       - name: Secret Scanning
-        uses: trufflesecurity/trufflehog@907ac64fd42b18dab2ceba2fda39834d3f8ba7e3 # v3.90.1
+        uses: trufflesecurity/trufflehog@a05cf0859455b5b16317ee22d809887a4043cdf0 # v3.90.2
         with:
           extra_args: --results=verified,unknown


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the version of the TruffleHog action used in the GitHub Actions workflow for secret scanning.

* [`.github/workflows/common-code-checks.yml`](diffhunk://#diff-d4fd1616efd0d349042c6f234e04f6a67b1cf5c85a83ef463226a145f0c1cec6L181-R181): Updated the TruffleHog action from version `v3.90.1` (`907ac64fd42b18dab2ceba2fda39834d3f8ba7e3`) to version `v3.90.2` (`a05cf0859455b5b16317ee22d809887a4043cdf0`).