### PR TITLE
Update Grype and TruffleHog

### DIFF
--- a/.github/workflows/common-code-checks.yml
+++ b/.github/workflows/common-code-checks.yml
@@ -132,7 +132,7 @@ jobs:
           persist-credentials: false
       - name: Scan current project
         id: scan
-        uses: anchore/scan-action@df395807f4554463d4455b8047cf58e37b6acaae # v6.5.0
+        uses: anchore/scan-action@1638637db639e0ade3258b51db49a9a137574c3e # v6.5.1
         with:
           path: "."
         continue-on-error: true
@@ -141,7 +141,7 @@ jobs:
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
       - name: Scan current project
-        uses: anchore/scan-action@df395807f4554463d4455b8047cf58e37b6acaae # v6.5.0
+        uses: anchore/scan-action@1638637db639e0ade3258b51db49a9a137574c3e # v6.5.1
         with:
           path: "."
 
@@ -175,7 +175,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Secret Scanning
-        uses: trufflesecurity/trufflehog@a05cf0859455b5b16317ee22d809887a4043cdf0 # v3.90.2
+        uses: trufflesecurity/trufflehog@ed6d045b46642d0d94a60bdf9b1246aefbcf3d35 # v3.90.3
         with:
           extra_args: --results=verified,unknown
 


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates dependencies in the GitHub Actions workflow file `.github/workflows/common-code-checks.yml` to ensure the latest versions of the tools are used. These updates include minor version bumps for the Anchore scan action and TruffleHog secret scanning action.

### Dependency Updates:

* Updated `anchore/scan-action` from `v6.5.0` to `v6.5.1` in two locations to include the latest improvements and fixes. (`[[1]](diffhunk://#diff-d4fd1616efd0d349042c6f234e04f6a67b1cf5c85a83ef463226a145f0c1cec6L135-R135)`, `[[2]](diffhunk://#diff-d4fd1616efd0d349042c6f234e04f6a67b1cf5c85a83ef463226a145f0c1cec6L144-R144)`)
* Updated `trufflesecurity/trufflehog` from `v3.90.2` to `v3.90.3` for secret scanning to use the latest version. (`[.github/workflows/common-code-checks.ymlL178-R178](diffhunk://#diff-d4fd1616efd0d349042c6f234e04f6a67b1cf5c85a83ef463226a145f0c1cec6L178-R178)`)