### PR TITLE
Update License to Licence

### DIFF
--- a/.github/other-configurations/labeller.yml
+++ b/.github/other-configurations/labeller.yml
@@ -25,7 +25,7 @@ markdown:
               [
                 "docs/*.md",
                 "*.md",
-                "LICENSE",
+                "LICENCE",
                 ".github/pull_request_template.md",
               ]
 python:


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a minor correction to the file pattern matching for documentation-related files in the `.github/other-configurations/labeller.yml` configuration.

* Changed the pattern from `"LICENSE"` to `"LICENCE"` to correctly match the intended file name.