### PR TITLE
Update checkout action to v5

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -22,7 +22,7 @@ jobs:
       statuses: write
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -19,7 +19,7 @@ jobs:
       security-events: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/common-clean-caches.yml
+++ b/.github/workflows/common-clean-caches.yml
@@ -17,7 +17,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/common-code-checks.yml
+++ b/.github/workflows/common-code-checks.yml
@@ -21,7 +21,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -54,7 +54,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -68,7 +68,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -94,7 +94,7 @@ jobs:
       security-events: write
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -109,7 +109,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -126,7 +126,7 @@ jobs:
       security-events: write
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -153,7 +153,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -170,7 +170,7 @@ jobs:
       security-events: write
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -184,7 +184,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/common-pull-request-tasks.yml
+++ b/.github/workflows/common-pull-request-tasks.yml
@@ -43,7 +43,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/common-sync-labels.yml
+++ b/.github/workflows/common-sync-labels.yml
@@ -18,7 +18,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
           persist-credentials: false


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the GitHub Actions workflow configuration to use a newer version of the `actions/checkout` action across multiple workflow files. The change upgrades from version 4.2.2 to 5.0.0, which may include performance improvements, bug fixes, and new features provided by the upstream action.

GitHub Actions workflow upgrades:

* Upgraded `actions/checkout` from v4.2.2 to v5.0.0 in `.github/workflows/code-checks.yml`, `.github/workflows/codeql-analysis.yml`, `.github/workflows/common-clean-caches.yml`, `.github/workflows/common-code-checks.yml`, `.github/workflows/common-pull-request-tasks.yml`, `.github/workflows/common-sync-labels.yml`, and `.github/workflows/release.yml` to ensure all workflows use the latest stable version. [[1]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L25-R25) [[2]](diffhunk://#diff-63bd641104d10e25f141d518a16b22a151d125e12701df2f9e79734b23b90188L22-R22) [[3]](diffhunk://#diff-13fad14fa3972181d9dae18fc35384d3396e52fd6e985447df6b9257982ce9cbL20-R20) [[4]](diffhunk://#diff-d4fd1616efd0d349042c6f234e04f6a67b1cf5c85a83ef463226a145f0c1cec6L24-R24) [[5]](diffhunk://#diff-d4fd1616efd0d349042c6f234e04f6a67b1cf5c85a83ef463226a145f0c1cec6L43-R43) [[6]](diffhunk://#diff-d4fd1616efd0d349042c6f234e04f6a67b1cf5c85a83ef463226a145f0c1cec6L57-R57) [[7]](diffhunk://#diff-d4fd1616efd0d349042c6f234e04f6a67b1cf5c85a83ef463226a145f0c1cec6L71-R71) [[8]](diffhunk://#diff-d4fd1616efd0d349042c6f234e04f6a67b1cf5c85a83ef463226a145f0c1cec6L97-R97) [[9]](diffhunk://#diff-d4fd1616efd0d349042c6f234e04f6a67b1cf5c85a83ef463226a145f0c1cec6L112-R112) [[10]](diffhunk://#diff-d4fd1616efd0d349042c6f234e04f6a67b1cf5c85a83ef463226a145f0c1cec6L129-R129) [[11]](diffhunk://#diff-d4fd1616efd0d349042c6f234e04f6a67b1cf5c85a83ef463226a145f0c1cec6L156-R156) [[12]](diffhunk://#diff-d4fd1616efd0d349042c6f234e04f6a67b1cf5c85a83ef463226a145f0c1cec6L173-R173) [[13]](diffhunk://#diff-d4fd1616efd0d349042c6f234e04f6a67b1cf5c85a83ef463226a145f0c1cec6L187-R187) [[14]](diffhunk://#diff-8e050c25ae75261ac53540aafc083c0d1a07a7828f03e6e7e8d5d1b56618ff5bL46-R46) [[15]](diffhunk://#diff-40034e5eefaf1f265d1667a6ee84513b426b627a9e6f3f716171af668ea6941dL21-R21) [[16]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L23-R23)