### PR TITLE
Update Zizmor to 1.12.0

### DIFF
--- a/.github/workflows/common-code-checks.yml
+++ b/.github/workflows/common-code-checks.yml
@@ -99,10 +99,10 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Run zizmor 🌈
-        uses: zizmorcore/zizmor-action@f52a838cfabf134edcbaa7c8b3677dde20045018 # v0.1.1
+        uses: zizmorcore/zizmor-action@5ca5fc7a4779c5263a3ffa0e1f693009994446d1 # v0.1.2
         with:
           persona: auditor
-          version: 1.11.0
+          version: 1.12.0
 
   run-actionlint:
     name: Check GitHub Actions with Actionlint


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the configuration for the Zizmor code auditing step in the GitHub Actions workflow. The main change is upgrading the Zizmor GitHub Action to a newer version.

Workflow dependency update:

* Upgraded the Zizmor GitHub Action in `.github/workflows/common-code-checks.yml` from `v0.1.1` to `v0.1.2` and updated the Zizmor tool version from `1.11.0` to `1.12.0`.