### PR TITLE
Update Zizmor version to 1.12.1

### DIFF
--- a/.github/workflows/common-code-checks.yml
+++ b/.github/workflows/common-code-checks.yml
@@ -102,7 +102,7 @@ jobs:
         uses: zizmorcore/zizmor-action@5ca5fc7a4779c5263a3ffa0e1f693009994446d1 # v0.1.2
         with:
           persona: auditor
-          version: 1.12.0
+          version: 1.12.1
 
   run-actionlint:
     name: Check GitHub Actions with Actionlint


### PR DESCRIPTION
# Pull Request

## Description

This pull request makes a minor update to the workflow configuration, specifically bumping the version of the `zizmorcore/zizmor-action` used in `.github/workflows/common-code-checks.yml` from `1.12.0` to `1.12.1`. This ensures the workflow uses the latest patch release of the action.