### PR TITLE
Add Docker Dependabot Configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,9 @@ updates:
       cronjob: "30 7 * * *"
       timezone: "Europe/London"
     target-branch: "main"
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "cron"
+      cronjob: "30 7 * * *"
+      timezone: "Europe/London"


### PR DESCRIPTION
# Pull Request

## Description

This pull request adds configuration for Dependabot to monitor Docker dependencies alongside existing package ecosystems. The main change is the introduction of a new schedule for Docker updates.

Dependabot configuration updates:

* Added a new `package-ecosystem` entry for Docker in `.github/dependabot.yml`, specifying the root directory and scheduling it to run daily at 07:30 Europe/London time.