### PR TITLE
Remove Docker Dependabot Configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,9 +8,3 @@ updates:
       cronjob: "30 7 * * *"
       timezone: "Europe/London"
     target-branch: "main"
-  - package-ecosystem: "docker"
-    directory: "/"
-    schedule:
-      interval: "cron"
-      cronjob: "30 7 * * *"
-      timezone: "Europe/London"


### PR DESCRIPTION
# Pull Request

## Description

This pull request makes a small configuration update to the `.github/dependabot.yml` file, removing the Docker ecosystem from automatic dependency updates. This means Dependabot will no longer check for updates to Docker dependencies.