### PR TITLE
Update GitHub Actions

### DIFF
--- a/.github/workflows/common-code-checks.yml
+++ b/.github/workflows/common-code-checks.yml
@@ -222,7 +222,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Run Markdownlint
-        uses: DavidAnson/markdownlint-cli2-action@992badcdf24e3b8eb7e87ff9287fe931bcb00c6e # v20
+        uses: DavidAnson/markdownlint-cli2-action@992badcdf24e3b8eb7e87ff9287fe931bcb00c6e # v20.0.0
         with:
           config: ".github/tool-configurations/.markdownlint-cli2.jsonc"
           globs: |
@@ -258,7 +258,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Run Trivy vulnerability scanner in fs mode
-        uses: aquasecurity/trivy-action@915b19bbe73b92a6cf82a1bc12b087c9a19a5fe2 # 0.28.0
+        uses: aquasecurity/trivy-action@dc5a429b52fcf669ce959baa2c2dd26090d2a6c4 # 0.32.0
         with:
           scan-type: "fs"
           scan-ref: "."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
           persist-credentials: false
       - name: Generate release tag
         id: generate_release_tag
-        uses: amitsingh-007/next-release-tag@def0701f886e599c3605f1c46af7a9f6413637fe # v6.2.0
+        uses: amitsingh-007/next-release-tag@43666cc7d412293e514756c2796dcba08c678369 # v6.3.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           tag_prefix: "v"


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates several GitHub Actions to use newer versions of their respective actions in workflow configuration files. These changes help ensure that the workflows benefit from the latest features, bug fixes, and security improvements.

**Workflow action version upgrades:**

* Upgraded the `markdownlint-cli2-action` in `.github/workflows/common-code-checks.yml` from version `v20` to `v20.0.0` for improved clarity and consistency in versioning.
* Updated the `trivy-action` in `.github/workflows/common-code-checks.yml` from version `0.28.0` to `0.32.0` to incorporate the latest vulnerability scanning enhancements and fixes.
* Bumped the `next-release-tag` action in `.github/workflows/release.yml` from version `v6.2.0` to `v6.3.0` to use the latest release tag generation logic.