### PR TITLE
Move trivy config to configuration file

### DIFF
--- a/.github/workflows/common-code-checks.yml
+++ b/.github/workflows/common-code-checks.yml
@@ -262,5 +262,4 @@ jobs:
         with:
           scan-type: "fs"
           scan-ref: "."
-          scanners: vuln,secret,misconfig,license
           trivy-config: .github/tool-configurations/trivy.yaml


### PR DESCRIPTION
# Pull Request

## Description

This pull request makes a small change to the `.github/workflows/common-code-checks.yml` workflow configuration. The change removes the `scanners` parameter from the Trivy scan job.