### PR TITLE
Update dependency-review to 4.7.3

### DIFF
--- a/.github/workflows/common-pull-request-tasks.yml
+++ b/.github/workflows/common-pull-request-tasks.yml
@@ -48,6 +48,6 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Dependency Review
-        uses: actions/dependency-review-action@bc41886e18ea39df68b1b1245f4184881938e050 # v4.7.2
+        uses: actions/dependency-review-action@595b5aeba73380359d98a5e087f648dbb0edce1b # v4.7.3
         with:
           comment-summary-in-pr: on-failure


### PR DESCRIPTION
# Pull Request

## Description

This pull request makes a minor update to the GitHub Actions workflow by upgrading the `actions/dependency-review-action` from version 4.7.2 to 4.7.3. This ensures the workflow uses the latest improvements and fixes for dependency review.

* Upgraded `actions/dependency-review-action` in `.github/workflows/common-pull-request-tasks.yml` from v4.7.2 to v4.7.3.