### PR TITLE
Update actions/labeler to v6

### DIFF
--- a/.github/workflows/common-pull-request-tasks.yml
+++ b/.github/workflows/common-pull-request-tasks.yml
@@ -16,7 +16,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Label Pull Request
-        uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
+        uses: actions/labeler@634933edcd8ababfe52f92936142cc22ac488b1b # v6.0.1
         with:
           repo-token: "${{ secrets.workflow_github_token }}"
           configuration-path: .github/tool-configurations/labeller.yml


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the GitHub Actions workflow to use a newer version of the labeler action for pull requests.

Workflow dependency update:

* Upgraded the `actions/labeler` action in `.github/workflows/common-pull-request-tasks.yml` from version `v5.0.0` to `v6.0.1` to ensure the workflow uses the latest features and bug fixes.