### PR TITLE
Update Trufflehog to v3.90.6

### DIFF
--- a/.github/workflows/common-code-checks.yml
+++ b/.github/workflows/common-code-checks.yml
@@ -175,7 +175,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Secret Scanning
-        uses: trufflesecurity/trufflehog@0f58ae7c5036094a1e3e750d18772af92821b503 # v3.90.5
+        uses: trufflesecurity/trufflehog@18c7b1fc33e6c16b27ea66ff27cc7e642fb7cd0a # v3.90.6
         with:
           extra_args: --results=verified,unknown
 


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the secret scanning tool version in the GitHub Actions workflow to ensure the latest security checks are used.

* Dependency update:
  * Updated the `trufflesecurity/trufflehog` action in `.github/workflows/common-code-checks.yml` from version `v3.90.5` to `v3.90.6` for improved secret scanning.