### PR TITLE
Update Zizmor to 1.13.0

### DIFF
--- a/.github/workflows/common-code-checks.yml
+++ b/.github/workflows/common-code-checks.yml
@@ -102,7 +102,7 @@ jobs:
         uses: zizmorcore/zizmor-action@5ca5fc7a4779c5263a3ffa0e1f693009994446d1 # v0.1.2
         with:
           persona: auditor
-          version: 1.12.1
+          version: 1.13.0
 
   run-actionlint:
     name: Check GitHub Actions with Actionlint


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the version of the `zizmor-action` used in the common code checks workflow. The change ensures that the workflow uses the latest features and fixes from the action.

* Updated the `version` input for `zizmorcore/zizmor-action` in `.github/workflows/common-code-checks.yml` from `1.12.1` to `1.13.0`.