### PR TITLE
Update Setup UV Version

### DIFF
--- a/.github/workflows/common-code-checks.yml
+++ b/.github/workflows/common-code-checks.yml
@@ -59,7 +59,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@557e51de59eb14aaaba2ed9621916900a91d50c6 # v6.6.1
+        uses: astral-sh/setup-uv@b75a909f75acd358c2196fb9a5f1299a9a8868a4 # v6.7.0
       - name: Run Lefthook Validate
         run: uvx lefthook validate
 


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the GitHub Actions workflow to use the latest version of the `uv` setup action. This ensures that the CI pipeline benefits from recent improvements and bug fixes in the tool.

* Updated the `astral-sh/setup-uv` action from version `v6.6.1` to `v6.7.0` in `.github/workflows/common-code-checks.yml` to ensure the latest features and fixes are used in CI jobs.