### PR TITLE
Update Scan Action

### DIFF
--- a/.github/workflows/common-code-checks.yml
+++ b/.github/workflows/common-code-checks.yml
@@ -132,7 +132,7 @@ jobs:
           persist-credentials: false
       - name: Scan current project
         id: scan
-        uses: anchore/scan-action@1638637db639e0ade3258b51db49a9a137574c3e # v6.5.1
+        uses: anchore/scan-action@f6601287cdb1efc985d6b765bbf99cb4c0ac29d8 # v7.0.0
         with:
           path: "."
         continue-on-error: true
@@ -141,7 +141,7 @@ jobs:
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
       - name: Scan current project
-        uses: anchore/scan-action@1638637db639e0ade3258b51db49a9a137574c3e # v6.5.1
+        uses: anchore/scan-action@f6601287cdb1efc985d6b765bbf99cb4c0ac29d8 # v7.0.0
         with:
           path: "."
 


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the Anchore scan GitHub Action used in the `.github/workflows/common-code-checks.yml` workflow to a newer version. The action is now set to use version 7.0.0 instead of 6.5.1.

Dependency update:

* Updated the `anchore/scan-action` in two workflow steps from version `v6.5.1` to `v7.0.0` in `.github/workflows/common-code-checks.yml` to incorporate the latest features and fixes. [[1]](diffhunk://#diff-d4fd1616efd0d349042c6f234e04f6a67b1cf5c85a83ef463226a145f0c1cec6L135-R135) [[2]](diffhunk://#diff-d4fd1616efd0d349042c6f234e04f6a67b1cf5c85a83ef463226a145f0c1cec6L144-R144)