### PR TITLE
Update Pull Request Tasks Permissions

### DIFF
--- a/.github/workflows/pull-request-tasks.yml
+++ b/.github/workflows/pull-request-tasks.yml
@@ -4,8 +4,7 @@ on:
   pull_request:
     types: [opened, edited, synchronize]
 
-permissions:
-  pull-requests: read
+permissions: {}
 
 jobs:
   common-pull-request-tasks:


### PR DESCRIPTION
# Pull Request

## Description

This pull request makes a minor change to the GitHub Actions workflow configuration by updating the permissions for the workflow.

- Changed the `permissions` setting in `.github/workflows/pull-request-tasks.yml` from granting read access to `pull-requests` to an empty permissions object, effectively removing explicit permissions.