### PR TITLE
update

### DIFF
--- a/.github/workflows/common-code-checks.yml
+++ b/.github/workflows/common-code-checks.yml
@@ -149,8 +149,8 @@ jobs:
     name: Check for Secrets with Gitleaks
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: write
+      pull-requests: write # for annotations
+      security-events: write # to create secret scanning alerts
     steps:
       - name: Checkout Repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -166,8 +166,7 @@ jobs:
     name: Check for Secrets with TruffleHog
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      security-events: write
+      security-events: write # to create secret scanning alerts
     steps:
       - name: Checkout Repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -251,6 +250,9 @@ jobs:
   run-trivy:
     name: "Check Vulnerabilities, Secrets, Misconfigurations, and Licenses with Trivy"
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
     steps:
       - name: Checkout Repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the permissions configuration for several jobs in the `.github/workflows/common-code-checks.yml` workflow file to ensure proper access for secret scanning and vulnerability checks. The changes mainly focus on refining the permissions needed by the Gitleaks, TruffleHog, and Trivy jobs.

**Secret scanning and vulnerability check permissions:**

* For the Gitleaks job, replaced `contents: read` with `security-events: write` and clarified the need for `pull-requests: write` for annotations.
* For the TruffleHog job, removed `contents: read` and kept only `security-events: write` for secret scanning alerts.
* For the Trivy job, added a new `permissions` section with `contents: read` and `security-events: write` to support vulnerability and secret scanning.