### PR TITLE
Turn on GitLeaks Artifact Upload

### DIFF
--- a/.github/workflows/common-code-checks.yml
+++ b/.github/workflows/common-code-checks.yml
@@ -160,6 +160,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
           GITLEAKS_ENABLE_UPLOAD_ARTIFACT: "true"
+          GITLEAKS_NOTIFY_USER_LIST: "@JackPlowman"
+      - name: LS
+        run: ls -la
 
   run-trufflehog:
     name: Check for Secrets with TruffleHog

--- a/.github/workflows/common-code-checks.yml
+++ b/.github/workflows/common-code-checks.yml
@@ -159,6 +159,7 @@ jobs:
         uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2.3.9
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          GITLEAKS_ENABLE_UPLOAD_ARTIFACT : "true"
 
   run-trufflehog:
     name: Check for Secrets with TruffleHog

--- a/.github/workflows/common-code-checks.yml
+++ b/.github/workflows/common-code-checks.yml
@@ -161,8 +161,10 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
           GITLEAKS_ENABLE_UPLOAD_ARTIFACT: "true"
           GITLEAKS_NOTIFY_USER_LIST: "@JackPlowman"
-      - name: LS
-        run: ls -la
+      - name: Upload Anchore scan SARIF report
+        uses: github/codeql-action/upload-sarif@3599b3baa15b485a2e49ef411a7a4bb2452e7f93 # v3.30.5
+        with:
+          sarif_file: results.sarif
 
   run-trufflehog:
     name: Check for Secrets with TruffleHog

--- a/.github/workflows/common-code-checks.yml
+++ b/.github/workflows/common-code-checks.yml
@@ -159,7 +159,7 @@ jobs:
         uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2.3.9
         env:
           GITHUB_TOKEN: ${{ github.token }}
-          GITLEAKS_ENABLE_UPLOAD_ARTIFACT : "true"
+          GITLEAKS_ENABLE_UPLOAD_ARTIFACT: "true"
 
   run-trufflehog:
     name: Check for Secrets with TruffleHog


### PR DESCRIPTION
# Pull Request

## Description

This pull request makes a small configuration change to the `.github/workflows/common-code-checks.yml` file. The change enables artifact uploads for the Gitleaks action, which can help with auditing and debugging secret scan results.

* CI configuration: Enabled artifact upload for the Gitleaks GitHub Action by setting `GITLEAKS_ENABLE_UPLOAD_ARTIFACT` to `"true"` in the workflow environment variables.