### PR TITLE
Update Zizmor version to v1.14.2

### DIFF
--- a/.github/workflows/common-code-checks.yml
+++ b/.github/workflows/common-code-checks.yml
@@ -101,7 +101,7 @@ jobs:
         uses: zizmorcore/zizmor-action@e673c3917a1aef3c65c972347ed84ccd013ecda4 # v0.2.0
         with:
           persona: auditor
-          version: 1.14.1
+          version: 1.14.2
 
   run-actionlint:
     name: Check GitHub Actions with Actionlint


### PR DESCRIPTION
# Pull Request

## Description

This pull request makes a minor update to the `.github/workflows/common-code-checks.yml` workflow file, specifically bumping the version of the `zizmorcore/zizmor-action` used for code audits.

* Increased the `version` of the `zizmorcore/zizmor-action` step from `1.14.1` to `1.14.2` to use the latest improvements or fixes in the action.