### PR TITLE
Update GitHub Actions

### DIFF
--- a/.github/workflows/common-code-checks.yml
+++ b/.github/workflows/common-code-checks.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Set up Just
         uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3.1.0
       - name: Run Prek Action
-        uses: j178/prek-action@79f765515bd648eb4d6bb1b17277b7cb22cb6468 # v2.0.0
+        uses: j178/prek-action@53276d8b0d10f8b6672aa85b4588c6921d0370cc # v2.0.1
         with:
           prek-version: "0.3.5"
           install-only: "true"
@@ -102,7 +102,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Run Actionlint
-        uses: docker://rhysd/actionlint:1.7.11 # zizmor: ignore[unpinned-uses]
+        uses: docker://rhysd/actionlint:1.7.12 # zizmor: ignore[unpinned-uses]
         with:
           args: -color
 
@@ -199,7 +199,7 @@ jobs:
       - name: Set up Just
         uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3.1.0
       - name: Run Prek Action
-        uses: j178/prek-action@79f765515bd648eb4d6bb1b17277b7cb22cb6468 # v2.0.0
+        uses: j178/prek-action@53276d8b0d10f8b6672aa85b4588c6921d0370cc # v2.0.1
         with:
           prek-version: "0.3.5"
 
@@ -258,7 +258,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Secret Scanning
-        uses: trufflesecurity/trufflehog@586f66d7886cd0b037c7c245d4a6e34ef357ab10 # v3.94.1
+        uses: trufflesecurity/trufflehog@6bd2d14f7a4bc1e569fa3550efa7ec632a4fa67b # v3.94.2
         with:
           extra_args: --results=verified,unknown
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
         description: Scan for secrets using Gitleaks
         language_version: "go1.25"
   - repo: https://github.com/rhysd/actionlint
-    rev: v1.7.11
+    rev: v1.7.12
     hooks:
       - id: actionlint
         name: Actionlint
@@ -60,7 +60,7 @@ repos:
         language: python
         entry: just
         additional_dependencies:
-          - rust-just==1.47.1
+          - rust-just==1.48.1
         args: ["format-check"]
         files: "(?i)(^justfile$|\\.just$)"
         pass_filenames: false


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates several dependencies used in CI workflows and pre-commit hooks to their latest patch versions, ensuring the codebase benefits from the latest bug fixes and improvements.

**CI workflow dependency updates:**

* Updated `j178/prek-action` from v2.0.0 to v2.0.1 in `.github/workflows/common-code-checks.yml` for both relevant jobs, providing the latest fixes for the Prek Action. [[1]](diffhunk://#diff-d4fd1616efd0d349042c6f234e04f6a67b1cf5c85a83ef463226a145f0c1cec6L88-R88) [[2]](diffhunk://#diff-d4fd1616efd0d349042c6f234e04f6a67b1cf5c85a83ef463226a145f0c1cec6L202-R202)
* Updated `rhysd/actionlint` Docker image from 1.7.11 to 1.7.12 in `.github/workflows/common-code-checks.yml`, and updated the corresponding pre-commit hook in `.pre-commit-config.yaml` to match. [[1]](diffhunk://#diff-d4fd1616efd0d349042c6f234e04f6a67b1cf5c85a83ef463226a145f0c1cec6L105-R105) [[2]](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9L30-R30)
* Updated `trufflesecurity/trufflehog` from v3.94.1 to v3.94.2 in `.github/workflows/common-code-checks.yml` for improved secret scanning.

**Pre-commit hook dependency updates:**

* Updated `rust-just` from 1.47.1 to 1.48.1 in `.pre-commit-config.yaml` to use the latest version for formatting checks.