### PR TITLE
Update Prek Hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -69,7 +69,7 @@ repos:
         language: golang
         entry: pinact
         additional_dependencies:
-          - github.com/suzuki-shunsuke/pinact/v3/cmd/pinact@v3.9.2
+          - github.com/suzuki-shunsuke/pinact/v4/cmd/pinact@v4.1.0
         args:
           [
             "run",
@@ -80,3 +80,4 @@ repos:
           ]
         files: "^\\.github/(workflows|actions)/.*\\.ya?ml$|(^|/)action\\.ya?ml$"
         pass_filenames: false
+        language_version: "go1.26.4"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,7 @@ repos:
         name: EditorConfig Checker
         description: Validates files against .editorconfig rules
   - repo: https://github.com/zizmorcore/zizmor-pre-commit
-    rev: v1.24.1
+    rev: v1.25.2
     hooks:
       - id: zizmor
         name: Zizmor


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the `.pre-commit-config.yaml` file to improve tooling and compatibility for pre-commit hooks. The main changes include updating dependencies for the Zizmor and Pinact hooks, and specifying the Go language version for the Pinact hook.

Dependency updates:

* Updated the `zizmor-pre-commit` hook to use version `v1.25.2` for improved checks and bug fixes.
* Updated the `pinact` dependency to use `v4.1.0` (from `v3.9.2`) to ensure compatibility with the latest features and fixes.

Configuration improvements:

* Set the `language_version` for the `pinact` hook to `"go1.26.4"` to ensure consistent execution across environments.