### PR TITLE
Update Prek Freeze Command

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 # Pre-commit configuration for use with `prek` (https://github.com/j178/prek)
 
-minimum_prek_version: "0.3.0"
+minimum_prek_version: "0.4.0"
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/Justfile
+++ b/Justfile
@@ -99,7 +99,7 @@ prek-update:
 
 # Prek update hooks
 prek-update-hooks:
-    prek autoupdate --freeze
+    prek update --freeze
 
 prek-update-additional-dependencies:
     uv run --script https://raw.githubusercontent.com/JackPlowman/update-prek-additional-dependencies/refs/heads/main/update_prek_additional_dependencies.py


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the pre-commit tooling to use newer versions and commands. The most important changes are:

Pre-commit tooling updates:

* Updated the minimum required version of `prek` from `0.3.0` to `0.4.0` in `.pre-commit-config.yaml`.
* Changed the `prek-update-hooks` command in the `Justfile` to use `prek update --freeze` instead of the deprecated `prek autoupdate --freeze`.