### PR TITLE
Update GitHub Actions and Hooks

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -26,10 +26,10 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
+        uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
         with:
           languages: ${{ inputs.language }}
           queries: security-and-quality
           config-file: GitHubSecurityLab/CodeQL-Community-Packs/configs/default.yml@v0.2.1
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
+        uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0

--- a/.github/workflows/common-code-checks.yml
+++ b/.github/workflows/common-code-checks.yml
@@ -139,7 +139,7 @@ jobs:
           GITLEAKS_ENABLE_UPLOAD_ARTIFACT: "true"
           GITLEAKS_NOTIFY_USER_LIST: "@JackPlowman"
       - name: Upload Anchore scan SARIF report
-        uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
+        uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
         with:
           sarif_file: results.sarif
 
@@ -161,7 +161,7 @@ jobs:
           path: "."
         continue-on-error: true
       - name: Upload Anchore scan SARIF report
-        uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
+        uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
       - name: Scan current project
@@ -242,7 +242,7 @@ jobs:
           output: "trivy-results.sarif"
           version: v0.71.2
       - name: Upload Trivy SARIF report
-        uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
+        uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
         with:
           sarif_file: trivy-results.sarif
 
@@ -258,7 +258,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Secret Scanning
-        uses: trufflesecurity/trufflehog@00155c9dc586f34d189adc83d3ac2698c2ec551f # v3.95.8
+        uses: trufflesecurity/trufflehog@27b0417c16317ca9a472a9a8092acce143b49c55 # v3.95.9
         with:
           extra_args: --results=verified,unknown
 

--- a/.github/workflows/common-code-checks.yml
+++ b/.github/workflows/common-code-checks.yml
@@ -87,7 +87,7 @@ jobs:
       - name: Run Prek Action
         uses: j178/prek-action@e98a699c41eb69ab013a45817a0406469a748f8d # v2.0.5
         with:
-          prek-version: "0.4.5"
+          prek-version: "0.4.8"
           install-only: "true"
       - name: Prek Check
         run: just prek-check
@@ -201,7 +201,7 @@ jobs:
       - name: Run Prek Action
         uses: j178/prek-action@e98a699c41eb69ab013a45817a0406469a748f8d # v2.0.5
         with:
-          prek-version: "0.4.5"
+          prek-version: "0.4.8"
 
   run-prettier:
     name: "Check Code Formatting with Prettier"
@@ -215,7 +215,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       - name: Install Prettier
-        run: npm install -g prettier@3.9.0 # zizmor: ignore[adhoc-packages]
+        run: npm install -g prettier@3.9.5 # zizmor: ignore[adhoc-packages]
       - name: Set up Just
         uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
       - name: Check Code Formatting with Prettier

--- a/.github/workflows/common-pull-request-tasks.yml
+++ b/.github/workflows/common-pull-request-tasks.yml
@@ -34,7 +34,7 @@ jobs:
       pull-requests: write # to create and update PR labels
     steps:
       - name: Label Pull Request
-        uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213 # v6.1.0
+        uses: actions/labeler@b8dd2d9be0f68b860e7dae5dae7d772984eacd6d # v6.2.0
         with:
           repo-token: "${{ secrets.workflow_github_token }}"
           configuration-path: .github/tool-configurations/labeller.yml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,7 +52,7 @@ repos:
         language: node
         entry: prettier
         additional_dependencies:
-          - prettier@3.9.4
+          - prettier@3.9.5
         args: ["--check"]
         files: "(?i)(\\.(md|markdown|ya?ml|json)$|^(README|LICENSE|CONTRIBUTING|CODE_OF_CONDUCT|SECURITY|SUPPORT)(\\.md)?$)"
       - id: justfile-format-check
@@ -60,7 +60,7 @@ repos:
         language: python
         entry: just
         additional_dependencies:
-          - rust-just==1.55.1
+          - rust-just==1.56.0
         args: ["format-check"]
         files: "(?i)(^justfile$|\\.just$)"
         pass_filenames: false


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates several dependencies and actions in the CI workflows and pre-commit configuration to use the latest versions, ensuring improved security, compatibility, and access to new features.

**CI workflow dependency updates:**

* Updated all usages of `github/codeql-action` (`init`, `analyze`, and `upload-sarif`) to version `v4.37.0` in `.github/workflows/codeql-analysis.yml` and `.github/workflows/common-code-checks.yml`, ensuring the latest CodeQL features and fixes are used. [[1]](diffhunk://#diff-63bd641104d10e25f141d518a16b22a151d125e12701df2f9e79734b23b90188L29-R35) [[2]](diffhunk://#diff-d4fd1616efd0d349042c6f234e04f6a67b1cf5c85a83ef463226a145f0c1cec6L142-R142) [[3]](diffhunk://#diff-d4fd1616efd0d349042c6f234e04f6a67b1cf5c85a83ef463226a145f0c1cec6L164-R164) [[4]](diffhunk://#diff-d4fd1616efd0d349042c6f234e04f6a67b1cf5c85a83ef463226a145f0c1cec6L245-R245)
* Updated `actions/labeler` to version `v6.2.0` in `.github/workflows/common-pull-request-tasks.yml` for improved pull request labeling.
* Updated `trufflesecurity/trufflehog` to version `v3.95.9` for secret scanning in `.github/workflows/common-code-checks.yml`.

**Tool version bumps:**

* Updated `prek-action` to use `prek-version` `0.4.8` (from `0.4.5`) in `.github/workflows/common-code-checks.yml` for both install and run steps. [[1]](diffhunk://#diff-d4fd1616efd0d349042c6f234e04f6a67b1cf5c85a83ef463226a145f0c1cec6L90-R90) [[2]](diffhunk://#diff-d4fd1616efd0d349042c6f234e04f6a67b1cf5c85a83ef463226a145f0c1cec6L204-R204)
* Updated Prettier to `3.9.5` in both `.github/workflows/common-code-checks.yml` and `.pre-commit-config.yaml` for code formatting checks. [[1]](diffhunk://#diff-d4fd1616efd0d349042c6f234e04f6a67b1cf5c85a83ef463226a145f0c1cec6L218-R218) [[2]](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9L55-R63)
* Updated `rust-just` to `1.56.0` in `.pre-commit-config.yaml` for Justfile format checks.
