### PR TITLE
Update GitHub Actions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -26,10 +26,10 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
+        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           languages: ${{ inputs.language }}
           queries: security-and-quality
           config-file: GitHubSecurityLab/CodeQL-Community-Packs/configs/default.yml@v0.5.1
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
+        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3

--- a/.github/workflows/common-code-checks.yml
+++ b/.github/workflows/common-code-checks.yml
@@ -139,7 +139,7 @@ jobs:
           GITLEAKS_ENABLE_UPLOAD_ARTIFACT: "true"
           GITLEAKS_NOTIFY_USER_LIST: "@JackPlowman"
       - name: Upload Anchore scan SARIF report
-        uses: github/codeql-action/upload-sarif@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
+        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           sarif_file: results.sarif
 
@@ -161,7 +161,7 @@ jobs:
           path: "."
         continue-on-error: true
       - name: Upload Anchore scan SARIF report
-        uses: github/codeql-action/upload-sarif@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
+        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
       - name: Scan current project
@@ -242,7 +242,7 @@ jobs:
           output: "trivy-results.sarif"
           version: v0.71.2
       - name: Upload Trivy SARIF report
-        uses: github/codeql-action/upload-sarif@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
+        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           sarif_file: trivy-results.sarif
 
@@ -294,7 +294,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Run zizmor 🌈
-        uses: zizmorcore/zizmor-action@6599ee8b7a49aef6a770f63d261d214911a7ce02 # v0.6.0
+        uses: zizmorcore/zizmor-action@6fc4b006235f201fdab3722e17240ab420d580e5 # v0.6.1
         with:
           persona: auditor
           version: 1.26.1

--- a/.github/workflows/common-pull-request-tasks.yml
+++ b/.github/workflows/common-pull-request-tasks.yml
@@ -34,7 +34,7 @@ jobs:
       pull-requests: write # to create and update PR labels
     steps:
       - name: Label Pull Request
-        uses: actions/labeler@b8dd2d9be0f68b860e7dae5dae7d772984eacd6d # v6.2.0
+        uses: actions/labeler@bf12e9b00b37c5c0ca2b87b79b2daf7891dbda13 # v7.0.0
         with:
           repo-token: "${{ secrets.workflow_github_token }}"
           configuration-path: .github/tool-configurations/labeller.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
           persist-credentials: false
       - name: Generate release tag
         id: generate_release_tag
-        uses: amitsingh-007/next-release-tag@ccca26be97e8a3e33f50ec71a42bdd596cbc249f # v6.5.0
+        uses: amitsingh-007/next-release-tag@f0ea640ef142d04e2f91e1df087f6782585548af # v6.6.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           tag_prefix: "v"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,7 @@ repos:
         name: EditorConfig Checker
         description: Validates files against .editorconfig rules
   - repo: https://github.com/zizmorcore/zizmor-pre-commit
-    rev: 64a97fb7fa63188393d3215c6e312f5f9c6d0f78 # frozen: v1.27.0
+    rev: 067260dc5fe6ea86b7551bfd6f8b3ba4e6c93129 # frozen: v1.28.0
     hooks:
       - id: zizmor
         name: Zizmor
@@ -52,7 +52,7 @@ repos:
         language: node
         entry: prettier
         additional_dependencies:
-          - prettier@3.9.5
+          - prettier@3.9.6
         args: ["--check"]
         files: "(?i)(\\.(md|markdown|ya?ml|json)$|^(README|LICENSE|CONTRIBUTING|CODE_OF_CONDUCT|SECURITY|SUPPORT)(\\.md)?$)"
       - id: justfile-format-check


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates several GitHub Actions and pre-commit hooks to their latest versions, ensuring improved features, bug fixes, and security enhancements across CI/CD workflows and code quality tools.

**CI/CD Workflow Updates:**

* Updated the `github/codeql-action` steps (`init`, `analyze`, and `upload-sarif`) to version `v4.37.3` in `.github/workflows/codeql-analysis.yml` and `.github/workflows/common-code-checks.yml`. [[1]](diffhunk://#diff-63bd641104d10e25f141d518a16b22a151d125e12701df2f9e79734b23b90188L29-R35) [[2]](diffhunk://#diff-d4fd1616efd0d349042c6f234e04f6a67b1cf5c85a83ef463226a145f0c1cec6L142-R142) [[3]](diffhunk://#diff-d4fd1616efd0d349042c6f234e04f6a67b1cf5c85a83ef463226a145f0c1cec6L164-R164) [[4]](diffhunk://#diff-d4fd1616efd0d349042c6f234e04f6a67b1cf5c85a83ef463226a145f0c1cec6L245-R245)
* Updated `actions/labeler` to version `v7.0.0` in `.github/workflows/common-pull-request-tasks.yml`.
* Updated `amitsingh-007/next-release-tag` to version `v6.6.0` in `.github/workflows/release.yml`.
* Updated `zizmorcore/zizmor-action` to version `v0.6.1` in `.github/workflows/common-code-checks.yml`.

**Pre-commit Hook Updates:**

* Updated `zizmorcore/zizmor-pre-commit` to version `v1.28.0` in `.pre-commit-config.yaml`.
* Updated `prettier` to version `3.9.6` in `.pre-commit-config.yaml`.